### PR TITLE
Refactor Cookit project structure and ui

### DIFF
--- a/app/src/main/java/com/example/cookit/MainActivity.kt
+++ b/app/src/main/java/com/example/cookit/MainActivity.kt
@@ -1,36 +1,13 @@
 package com.example.cookit
 
-import RegistrationScreen
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
-import com.example.cookit.data.network.AuthRepository
-import com.example.cookit.data.network.HomeRepository
-import com.example.cookit.data.network.RetrofitInstance
-import com.example.cookit.ui.screens.addPost.AddRecipePostScreen
-import com.example.cookit.ui.screens.auth.LoginScreen
-import com.example.cookit.ui.screens.auth.SplashScreen
-import com.example.cookit.ui.screens.home.ExploreScreen
-import com.example.cookit.ui.screens.home.HomeScreen
-import com.example.cookit.ui.screens.home.RecipeScreen
-import com.example.cookit.ui.screens.home.UserProfileScreen
+import com.example.cookit.ui.navigation.AppNavHost
 import com.example.cookit.ui.theme.CookITTheme
-import com.example.cookit.utils.NavigationConstants
-import com.example.cookit.viewModel.AuthViewModel
-import com.example.cookit.viewModel.AuthViewModelFactory
-import com.example.cookit.viewModel.HomeViewModel
-import com.example.cookit.viewModel.HomeViewModelFactory
 
 class MainActivity : ComponentActivity() {
-    @OptIn(ExperimentalAnimationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -41,99 +18,3 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
-
-@Composable
-fun AppNavHost() {
-    val navController = rememberNavController()
-    val context = LocalContext.current
-
-    val authViewModel: AuthViewModel =
-        viewModel(factory = AuthViewModelFactory(AuthRepository(RetrofitInstance.api)))
-    val homeViewModel: HomeViewModel =
-        viewModel(factory = HomeViewModelFactory(HomeRepository(RetrofitInstance.api)))
-
-    NavHost(
-        navController = navController,
-        startDestination = NavigationConstants.SPLASH_SCREEN
-    ) {
-        composable(NavigationConstants.SPLASH_SCREEN) {
-            SplashScreen(
-                onNavigateToHome = {
-                    navController.navigate(NavigationConstants.HOME_SCREEN) {
-                        popUpTo(NavigationConstants.SPLASH_SCREEN) { inclusive = true }
-                    }
-                },
-                onNavigateToLogin = {
-                    navController.navigate(NavigationConstants.LOGIN_SCREEN) {
-                        popUpTo(NavigationConstants.SPLASH_SCREEN) { inclusive = true }
-                    }
-                },
-                viewModel = authViewModel
-            )
-        }
-
-        composable(NavigationConstants.LOGIN_SCREEN) {
-            LoginScreen(
-                onLoginSuccess = {
-                    navController.navigate(NavigationConstants.HOME_SCREEN) {
-                        popUpTo(NavigationConstants.SPLASH_SCREEN) { inclusive = true }
-                    }
-                },
-                onNavigateToRegister = {
-                    navController.navigate(NavigationConstants.REGISTER_SCREEN) {
-                        popUpTo(NavigationConstants.SPLASH_SCREEN) { inclusive = true }
-                    }
-                },
-                viewModel = authViewModel
-            )
-        }
-
-        composable(NavigationConstants.REGISTER_SCREEN) {
-            RegistrationScreen(
-                onRegistrationSuccess = {
-                    navController.navigate(NavigationConstants.HOME_SCREEN) {
-                        popUpTo(NavigationConstants.SPLASH_SCREEN) { inclusive = true }
-                    }
-                },
-                onNavigateBack = { navController.popBackStack() },
-                viewModel = authViewModel
-            )
-        }
-
-        composable(NavigationConstants.HOME_SCREEN) {
-            HomeScreen(navController = navController,homeViewModel)
-        }
-
-        composable(NavigationConstants.USER_PROFILE_ROUTE) { backStackEntry ->
-            val userId = backStackEntry.arguments?.getString("userId") ?: ""
-            UserProfileScreen(
-                navController = navController,
-                userId = userId,
-                viewModel = homeViewModel, {
-                    navController.popBackStack()
-                })
-        }
-        composable(NavigationConstants.USER_RECIPE_ROUTE) { backStackEntry ->
-            val recipeId = backStackEntry.arguments?.getString("recipeId") ?: ""
-            RecipeScreen(
-                navController = navController,
-                recipeId = recipeId,
-                viewModel = homeViewModel,
-                onBack = {
-                    navController.popBackStack()
-                },
-                onLikeClick = {
-                    homeViewModel.getRecipeLiked(recipeId)
-                }
-            )
-        }
-
-        composable(NavigationConstants.EXPLORE_SCREEN) { backStackEntry ->
-            ExploreScreen(navController = navController, homeViewModel)
-        }
-        composable(NavigationConstants.ADD_RECIPE_SCREEN) { backStackEntry ->
-            AddRecipePostScreen(homeViewModel,navController)
-        }
-    }
-}
-

--- a/app/src/main/java/com/example/cookit/ui/navigation/BottomNavBar.kt
+++ b/app/src/main/java/com/example/cookit/ui/navigation/BottomNavBar.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,14 +26,17 @@ fun BottomNavBar(
     selectedIndex: Int,
     onItemSelected: (Int) -> Unit
 ) {
-    BoxWithConstraints(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(65.dp)
-            .shadow(elevation = 20.dp)
-            .background(PrimaryColor)
-            .padding(top = 2.dp)
+    Surface(
+        tonalElevation = 3.dp,
+        shadowElevation = 8.dp,
+        color = MaterialTheme.colorScheme.primary,
     ) {
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(65.dp)
+                .padding(top = 2.dp)
+        ) {
         val baseIconSize = if (maxWidth < 380.dp) 24.dp else 28.dp
         val baseTextSize = if (maxWidth < 380.dp) 9.sp else 10.sp
         val selectedIconSizeIncrease = 4.dp
@@ -74,6 +79,7 @@ fun BottomNavBar(
                     )
                 }
             }
+        }
         }
     }
 }

--- a/app/src/main/java/com/example/cookit/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/cookit/ui/navigation/NavGraph.kt
@@ -1,0 +1,122 @@
+package com.example.cookit.ui.navigation
+
+import com.example.cookit.ui.screens.auth.RegistrationScreen
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.cookit.data.network.AuthRepository
+import com.example.cookit.data.network.HomeRepository
+import com.example.cookit.data.network.RetrofitInstance
+import com.example.cookit.ui.screens.addPost.AddRecipePostScreen
+import com.example.cookit.ui.screens.auth.LoginScreen
+import com.example.cookit.ui.screens.auth.SplashScreen
+import com.example.cookit.ui.screens.home.ExploreScreen
+import com.example.cookit.ui.screens.home.HomeScreen
+import com.example.cookit.ui.screens.home.RecipeScreen
+import com.example.cookit.ui.screens.home.UserProfileScreen
+import com.example.cookit.utils.NavigationConstants
+import com.example.cookit.viewModel.AuthViewModel
+import com.example.cookit.viewModel.AuthViewModelFactory
+import com.example.cookit.viewModel.HomeViewModel
+import com.example.cookit.viewModel.HomeViewModelFactory
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+fun AppNavHost() {
+    val navController = rememberNavController()
+    val context = LocalContext.current
+
+    val authViewModel: AuthViewModel =
+        viewModel(factory = AuthViewModelFactory(AuthRepository(RetrofitInstance.api)))
+    val homeViewModel: HomeViewModel =
+        viewModel(factory = HomeViewModelFactory(HomeRepository(RetrofitInstance.api)))
+
+    NavHost(
+        navController = navController,
+        startDestination = NavigationConstants.SPLASH_SCREEN
+    ) {
+        composable(NavigationConstants.SPLASH_SCREEN) {
+            SplashScreen(
+                onNavigateToHome = {
+                    navController.navigate(NavigationConstants.HOME_SCREEN) {
+                        popUpTo(NavigationConstants.SPLASH_SCREEN) { inclusive = true }
+                    }
+                },
+                onNavigateToLogin = {
+                    navController.navigate(NavigationConstants.LOGIN_SCREEN) {
+                        popUpTo(NavigationConstants.SPLASH_SCREEN) { inclusive = true }
+                    }
+                },
+                viewModel = authViewModel
+            )
+        }
+
+        composable(NavigationConstants.LOGIN_SCREEN) {
+            LoginScreen(
+                onLoginSuccess = {
+                    navController.navigate(NavigationConstants.HOME_SCREEN) {
+                        popUpTo(NavigationConstants.SPLASH_SCREEN) { inclusive = true }
+                    }
+                },
+                onNavigateToRegister = {
+                    navController.navigate(NavigationConstants.REGISTER_SCREEN) {
+                        popUpTo(NavigationConstants.SPLASH_SCREEN) { inclusive = true }
+                    }
+                },
+                viewModel = authViewModel
+            )
+        }
+
+        composable(NavigationConstants.REGISTER_SCREEN) {
+            RegistrationScreen(
+                onRegistrationSuccess = {
+                    navController.navigate(NavigationConstants.HOME_SCREEN) {
+                        popUpTo(NavigationConstants.SPLASH_SCREEN) { inclusive = true }
+                    }
+                },
+                onNavigateBack = { navController.popBackStack() },
+                viewModel = authViewModel
+            )
+        }
+
+        composable(NavigationConstants.HOME_SCREEN) {
+            HomeScreen(navController = navController, homeViewModel)
+        }
+
+        composable(NavigationConstants.USER_PROFILE_ROUTE) { backStackEntry ->
+            val userId = backStackEntry.arguments?.getString("userId") ?: ""
+            UserProfileScreen(
+                navController = navController,
+                userId = userId,
+                viewModel = homeViewModel, {
+                    navController.popBackStack()
+                })
+        }
+        composable(NavigationConstants.USER_RECIPE_ROUTE) { backStackEntry ->
+            val recipeId = backStackEntry.arguments?.getString("recipeId") ?: ""
+            RecipeScreen(
+                navController = navController,
+                recipeId = recipeId,
+                viewModel = homeViewModel,
+                onBack = {
+                    navController.popBackStack()
+                },
+                onLikeClick = {
+                    homeViewModel.getRecipeLiked(recipeId)
+                }
+            )
+        }
+
+        composable(NavigationConstants.EXPLORE_SCREEN) { backStackEntry ->
+            ExploreScreen(navController = navController, homeViewModel)
+        }
+        composable(NavigationConstants.ADD_RECIPE_SCREEN) { backStackEntry ->
+            AddRecipePostScreen(homeViewModel, navController)
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/cookit/ui/screens/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/cookit/ui/screens/auth/LoginScreen.kt
@@ -154,7 +154,7 @@ fun LoginScreen(
         if (uiState is AuthUiState.Error) {
             Text(
                 text = uiState.message,
-                color = Color.Red,
+                color = MaterialTheme.colorScheme.error,
                 style = MaterialTheme.typography.bodySmall
             )
         }

--- a/app/src/main/java/com/example/cookit/ui/screens/auth/RegistrationScreen.kt
+++ b/app/src/main/java/com/example/cookit/ui/screens/auth/RegistrationScreen.kt
@@ -1,3 +1,5 @@
+package com.example.cookit.ui.screens.auth
+
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -64,7 +66,7 @@ fun RegistrationScreen(
                 PrefManager.saveUserName(uiState.authResponse.user.name)
                 PrefManager.saveUserId(uiState.authResponse.user.id)
                 PrefManager.saveUserEmail(uiState.authResponse.user.email)
-                onRegistrationSuccess
+                onRegistrationSuccess()
             }
 
             is AuthUiState.Error -> {
@@ -192,7 +194,7 @@ fun RegistrationScreen(
         if (uiState is AuthUiState.Error) {
             Text(
                 text = uiState.message,
-                color = Color.Red,
+                color = MaterialTheme.colorScheme.error,
                 style = MaterialTheme.typography.bodySmall
             )
         }

--- a/app/src/main/java/com/example/cookit/ui/screens/home/ExploreScreen.kt
+++ b/app/src/main/java/com/example/cookit/ui/screens/home/ExploreScreen.kt
@@ -132,7 +132,7 @@ fun ExploreScreen(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(White)
+                    .background(MaterialTheme.colorScheme.background)
             ) {
                 items(filteredRecipes, key = { it._id }) { recipe ->
                     RecipeGridItem2(
@@ -227,10 +227,10 @@ fun RecipeGridItem2(
             .fillMaxWidth()
             .wrapContentHeight()
             .clip(RoundedCornerShape(16.dp))
-            .background(PrimaryColor)
+            .background(MaterialTheme.colorScheme.surface)
             .clickable { onClick() },
         shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = PrimaryColor),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
         elevation = CardDefaults.cardElevation(2.dp)
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -247,7 +247,7 @@ fun RecipeGridItem2(
             Text(
                 text = recipe.title,
                 style = MaterialTheme.typography.titleSmall,
-                color = White,
+                color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 2,
                 textAlign = TextAlign.Center,
                 modifier = Modifier

--- a/app/src/main/java/com/example/cookit/ui/screens/home/RecipeScreen.kt
+++ b/app/src/main/java/com/example/cookit/ui/screens/home/RecipeScreen.kt
@@ -1,6 +1,5 @@
 package com.example.cookit.ui.screens.home
 
-import android.R
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.foundation.background
@@ -123,7 +122,7 @@ fun RecipeScreen(
                     LazyColumn(
                         modifier = Modifier
                             .fillMaxSize()
-                            .background(PrimaryColor)
+                            .background(MaterialTheme.colorScheme.background)
                     ) {
                         // Top image
                         item {
@@ -151,12 +150,12 @@ fun RecipeScreen(
                                         .padding(16.dp)
                                         .size(50.dp)
                                         .clip(CircleShape)
-                                        .background(BackgroundColor)
+                                        .background(MaterialTheme.colorScheme.surface)
                                 ) {
                                     Icon(
                                         imageVector = if (isLiked.value) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
                                         contentDescription = "Like",
-                                        tint = if (isLiked.value) Color.Red else TextPrimary,
+                                        tint = if (isLiked.value) Color.Red else MaterialTheme.colorScheme.onSurface,
                                         modifier = Modifier.size(28.dp)
                                     )
                                 }
@@ -170,12 +169,12 @@ fun RecipeScreen(
                                     .fillMaxWidth()
                                     .padding(8.dp),
                                 shape = RoundedCornerShape(12.dp),
-                                colors = CardDefaults.cardColors(containerColor = BackgroundColor),
+                                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
                                 elevation = CardDefaults.cardElevation(0.dp)
                             ) {
                                 Column(Modifier
                                     .padding(16.dp)
-                                    .background(BackgroundColor)) {
+                                    .background(MaterialTheme.colorScheme.surface)) {
                                     Column(
                                         modifier = Modifier.fillMaxWidth(),
                                         verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -191,7 +190,7 @@ fun RecipeScreen(
                                                 style = MaterialTheme.typography.headlineSmall.copy(
                                                     fontWeight = FontWeight.Bold
                                                 ),
-                                                color = PrimaryColor,
+                                                color = MaterialTheme.colorScheme.onSurface,
                                                 maxLines = 2,
                                                 overflow = TextOverflow.Ellipsis, // prevents overlap
                                                 modifier = Modifier.weight(1f)
@@ -204,13 +203,13 @@ fun RecipeScreen(
                                                 Icon(
                                                     imageVector = Icons.Default.DateRange,
                                                     contentDescription = null,
-                                                    tint = PrimaryColor,
+                                                    tint = MaterialTheme.colorScheme.primary,
                                                     modifier = Modifier.size(18.dp)
                                                 )
                                                 Text(
                                                     text = "${recipe.cookTime} min",
                                                     fontWeight = FontWeight.SemiBold,
-                                                    color = TextPrimary
+                                                    color = MaterialTheme.colorScheme.onSurface
                                                 )
                                             }
                                         }
@@ -233,7 +232,7 @@ fun RecipeScreen(
                                                 },
                                                 shape = RoundedCornerShape(50),
                                                 colors = CardDefaults.cardColors(
-                                                    containerColor = PrimaryColor
+                                                    containerColor = MaterialTheme.colorScheme.primary
                                                 )
                                             ) {
                                                 Row(
@@ -254,7 +253,7 @@ fun RecipeScreen(
                                                     Text(
                                                         text = recipe.author.name,
                                                         fontWeight = FontWeight.Medium,
-                                                        color = White
+                                                        color = MaterialTheme.colorScheme.onPrimary
                                                     )
                                                 }
                                             }
@@ -267,13 +266,13 @@ fun RecipeScreen(
                                                 Icon(
                                                     imageVector = if (isLiked.value) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
                                                     contentDescription = null,
-                                                    tint = if (isLiked.value) Color.Red else TextPrimary,
+                                                    tint = if (isLiked.value) Color.Red else MaterialTheme.colorScheme.onSurface,
                                                     modifier = Modifier.size(20.dp)
                                                 )
                                                 Text(
                                                     text = "${likeCount.value} likes",
                                                     style = MaterialTheme.typography.bodyMedium,
-                                                    color = TextPrimary
+                                                    color = MaterialTheme.colorScheme.onSurface
                                                 )
                                             }
                                         }
@@ -286,7 +285,7 @@ fun RecipeScreen(
                                     Text(
                                         recipe.description,
                                         style = MaterialTheme.typography.bodyLarge,
-                                        color = TextPrimary
+                                        color = MaterialTheme.colorScheme.onSurface
                                     )
 
                                     Spacer(Modifier.height(18.dp))
@@ -296,7 +295,7 @@ fun RecipeScreen(
                                         "Ingredients",
                                         fontWeight = FontWeight.Bold,
                                         fontSize = 18.sp,
-                                        color = PrimaryColor
+                                        color = MaterialTheme.colorScheme.primary
                                     )
                                     Spacer(Modifier.height(8.dp))
                                     LazyRow(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -305,7 +304,8 @@ fun RecipeScreen(
                                                 onClick = {},
                                                 label = { Text(ingredient) },
                                                 colors = AssistChipDefaults.assistChipColors(
-                                                    containerColor = PrimaryColor
+                                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                                    labelColor = MaterialTheme.colorScheme.onSecondaryContainer
                                                 ),
                                                 modifier = Modifier.height(36.dp)
                                             )
@@ -319,7 +319,7 @@ fun RecipeScreen(
                                         "Steps",
                                         fontWeight = FontWeight.Bold,
                                         fontSize = 18.sp,
-                                        color = PrimaryColor
+                                        color = MaterialTheme.colorScheme.primary
                                     )
                                     Spacer(Modifier.height(8.dp))
                                     Column {
@@ -330,13 +330,13 @@ fun RecipeScreen(
                                             ) {
                                                 Surface(
                                                     shape = CircleShape,
-                                                    color = PrimaryColor,
+                                                    color = MaterialTheme.colorScheme.primary,
                                                     modifier = Modifier.size(28.dp)
                                                 ) {
                                                     Box(contentAlignment = Alignment.Center) {
                                                         Text(
                                                             "${index + 1}",
-                                                            color = White,
+                                                            color = MaterialTheme.colorScheme.onPrimary,
                                                             fontWeight = FontWeight.Bold
                                                         )
                                                     }
@@ -345,7 +345,7 @@ fun RecipeScreen(
                                                 Text(
                                                     step,
                                                     style = MaterialTheme.typography.bodyLarge,
-                                                    color = TextPrimary
+                                                    color = MaterialTheme.colorScheme.onSurface
                                                 )
                                             }
                                         }

--- a/app/src/main/java/com/example/cookit/ui/theme/Shapes.kt
+++ b/app/src/main/java/com/example/cookit/ui/theme/Shapes.kt
@@ -1,0 +1,14 @@
+package com.example.cookit.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+val AppShapes = Shapes(
+    extraSmall = RoundedCornerShape(6.dp),
+    small = RoundedCornerShape(8.dp),
+    medium = RoundedCornerShape(12.dp),
+    large = RoundedCornerShape(16.dp),
+    extraLarge = RoundedCornerShape(24.dp)
+)
+

--- a/app/src/main/java/com/example/cookit/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/cookit/ui/theme/Theme.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.material3.Shapes
 
 private val DarkColorScheme = darkColorScheme(
     primary = PrimaryColor,
@@ -64,6 +65,7 @@ fun CookITTheme(
     MaterialTheme(
         colorScheme = colorScheme,
         typography = Typography,
+        shapes = AppShapes,
         content = content
     )
 }


### PR DESCRIPTION
Refactor project structure by extracting navigation into `NavGraph.kt` and overhaul UI to leverage Material 3 theming.

This PR improves code organization by centralizing navigation logic and modernizes the UI with consistent Material 3 colors, shapes, and surfaces across various screens (Explore, Recipe, Auth) and the bottom navigation bar. It also includes a fix for a `RegistrationScreen` callback and package declaration.

---
<a href="https://cursor.com/background-agent?bcId=bc-9407db6e-2a92-4b3b-848e-20b1918ab3d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9407db6e-2a92-4b3b-848e-20b1918ab3d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

